### PR TITLE
Migrated Concierge service to use the new 2.0 Minid Client

### DIFF
--- a/api/migrations/0004_auto_20180628_1441.py
+++ b/api/migrations/0004_auto_20180628_1441.py
@@ -17,11 +17,15 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='bag',
             name='user',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                to=settings.AUTH_USER_MODEL),
         ),
         migrations.AlterField(
             model_name='stagebag',
             name='user',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                to=settings.AUTH_USER_MODEL),
         ),
     ]

--- a/api/migrations/0005_minid_to_identifier_service.py
+++ b/api/migrations/0005_minid_to_identifier_service.py
@@ -17,9 +17,12 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='TokenStore',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True, primary_key=True,
+                                        serialize=False, verbose_name='ID')),
                 ('token_store', models.TextField(blank=True)),
-                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    to=settings.AUTH_USER_MODEL)),
             ],
         ),
         migrations.RemoveField(

--- a/api/minid.py
+++ b/api/minid.py
@@ -1,42 +1,25 @@
 from __future__ import unicode_literals
 import logging
 import globus_sdk
-from minid_client import minid_client_api
-from identifiers_client.identifiers_api import IdentifierClient
-from django.conf import settings
+from minid import MinidClient
 from api.models import TokenStore
 
 log = logging.getLogger(__name__)
 
 
-def load_identifiers_client(user):
+def load_minid_client(user):
     token = TokenStore.get_id_token(user)
     log.debug('Identifier user {}, has token: {}' .format(user, bool(token)))
     ac = globus_sdk.AccessTokenAuthorizer(token) if token else None
-    cfg = {'app_name': 'Concierge Service', 'authorizer': ac}
-    return IdentifierClient(**cfg)
+    return MinidClient(authorizer=ac)
 
 
-def create_minid(user, filename, locations, metadata={},
-                 visible_to=('public',), test=True):
-    checksum = minid_client_api.compute_checksum(filename)
-    ic = load_identifiers_client(user)
-    log.debug('checksum: {}'.format(checksum))
-    namespace = (settings.TEST_IDENTIFIER_NAMESPACE
-                 if test else settings.IDENTIFIER_NAMESPACE)
-    log.debug('Test is {}, using namespace {}'.format(test, namespace))
-
-    kwargs = {
-        'namespace': namespace,
-        'visible_to': visible_to,
-        'location': locations,
-        'checksums': [{
+def create_minid(user, filename, locations, metadata=None, test=True):
+    mc = load_minid_client(user)
+    checksums = [{
           'function': 'sha256',
-          'value': checksum
-        }],
-        'metadata': metadata
-    }
-    minid = ic.create_identifier(**kwargs)
-    log.debug('Created new minid for user {}: {}'.format(user.username, minid))
-
+          'value': MinidClient.compute_checksum(filename)
+        }]
+    minid = mc.register(checksums, title=filename, locations=locations,
+                        test=test, metadata=metadata)
     return minid

--- a/api/models.py
+++ b/api/models.py
@@ -33,7 +33,8 @@ class TokenStore(models.Model):
 
     @staticmethod
     def get_id_token(user):
-        return TokenStore.get_token(user, 'identifiers.globus.org')
+        return TokenStore.get_token(user,
+                                    '85114005-42e6-4671-a73a-0a40150c2b88')
 
     @staticmethod
     def get_transfer_token(user):
@@ -44,7 +45,6 @@ class Bag(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     minid = models.CharField(max_length=30)
     location = models.CharField(max_length=255)
-
 
 
 class StageBag(models.Model):

--- a/api/utils.py
+++ b/api/utils.py
@@ -12,7 +12,7 @@ from six.moves.urllib_parse import urlsplit
 from django.conf import settings
 import bagit
 from bdbag import bdbag_api
-from identifiers_client.identifiers_api import IdentifierClientError
+from fair_identifiers_client.identifiers_api import IdentifierClientError
 
 from api.models import Bag
 from api.exc import NoDataToTransfer, ConciergeException
@@ -124,6 +124,7 @@ def create_bag_archive(manifest, bag_metadata, ro_metadata, name):
         os.remove(remote_manifest_filename)
         return archive_name
     except Exception as e:
+        log.exception(e)
         raise ConciergeException(str(e), code='bdbag_creation_error')
 
 
@@ -158,8 +159,8 @@ def _resolve_minids_to_bags(user, minids):
                     if b not in [bg.minid for bg in bags]]
         for bag_minid in bad_bags:
             try:
-                ic = minid.load_identifiers_client(user)
-                minid_resp = ic.get_identifier(bag_minid).data
+                mc = minid.load_minid_client(user)
+                minid_resp = mc.check(bag_minid).data
                 if not minid_resp['location']:
                     raise ConciergeException({'error': 'Minid has no location '
                                              '{}'.format(minid)})

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ django==1.11.28
 djangorestframework==3.9.1
 django-rest-swagger==2.1.2
 boto3>=1.7.0
-globus-sdk==1.5.0
+globus-sdk>=1.5.0
 bdbag==1.3.0
-minid==1.2.3
--e git+https://github.com/globus/globus-identifiers-client#egg=globus-identifiers-client
+minid>=2.0.0b3


### PR DESCRIPTION
The Minid Client 2.0 beta is out, this switches Minids over to the new client. This is vital, as the old service needs to be shut down. Concierge will rely on the new fair identifiers service here: https://github.com/fair-research/fair-identifiers-service